### PR TITLE
Add debug log paths to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ Tested on Ubuntu 20.04; the following pre-requisite packages must be installed t
 ```sh
 $ sudo apt install zenity libayatana-appindicator3-dev
 ```
+## Debug Log Paths
+Depending on what operating system you use the debug log path will be different
+
+**Windows Path:** ```%LOCALAPPDATA%\.walltaker\logs\walltaker.log```
+
+**Linux Path:** ```~/.cache/.walltaker/logs/walltaker.log```
+
+**Mac OSX Path:** ```~/Library/Caches/.walltaker/logs/walltaker.log```
 
 ## Thanks
 Special thanks to Gray over at joi.how for putting together the Walltaker project!


### PR DESCRIPTION
Adding the debug log paths to the readme as discussed here
https://github.com/PawCorp/walltaker-desktop-client/issues/35