### PR TITLE
#45 Arch/Garuda Requirements in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,22 @@ v2.1.0+ - Now using websockets!
 
 ### Linux
 
+#### Ubuntu/Debian
+
 Tested on Ubuntu 20.04; the following pre-requisite packages must be installed to run Walltaker 2.0.0+.
 
 ```sh
 $ sudo apt install zenity libayatana-appindicator3-dev
 ```
+
+#### Arch
+
+Tested on Garuda Linux, per community request
+
+```sh
+$ sudo pacman -S zenity libayatana-appindicator appmenu-gtk-module
+```
+
 ## Debug Log Paths
 Depending on what operating system you use the debug log path will be different
 


### PR DESCRIPTION
Resolves #45 by adding install command for arch requirements, tested on Garuda linux

follow up with pull of `main/` into `develop/`